### PR TITLE
Workaround for fitBounds

### DIFF
--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
@@ -895,11 +895,15 @@ public class RCTMGLMapView extends MapView implements
         WritableMap payload = new WritableNativeMap();
         AndroidCallbackEvent event = new AndroidCallbackEvent(this, callbackID, EventKeys.MAP_ANDROID_CALLBACK);
 
+        // pad format T R B L
+        // getCamaeraForlatLngBounds expects L T R B
+        // https://github.com/mapbox/mapbox-gl-native/blob/cf4b4e728c26e444514f6ba792c207692350eb57/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java#L238-L241
+        // https://github.com/mapbox/mapbox-gl-native/blob/cf4b4e728c26e444514f6ba792c207692350eb57/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java#L910
         int[] padding = {
-                pad.getInt(0),
-                pad.getInt(1),
-                pad.getInt(2),
-                pad.getInt(3),
+                pad.getInt(3), // left
+                pad.getInt(0), // top
+                pad.getInt(1), // right
+                pad.getInt(2), // bottom
         };
 
         LatLngBounds latLngBounds = LatLngBounds.from(

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
@@ -32,6 +32,7 @@ import com.mapbox.mapboxsdk.camera.CameraPosition;
 import com.mapbox.mapboxsdk.camera.CameraUpdate;
 import com.mapbox.mapboxsdk.camera.CameraUpdateFactory;
 import com.mapbox.mapboxsdk.geometry.LatLng;
+import com.mapbox.mapboxsdk.geometry.LatLngBounds;
 import com.mapbox.mapboxsdk.geometry.VisibleRegion;
 import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
@@ -422,6 +422,11 @@ public class RCTMGLMapView extends MapView implements
                 long curTimestamp = System.currentTimeMillis();
                 boolean curAnimated = mCameraChangeTracker.isAnimated();
                 if (curTimestamp - lastTimestamp < 500 && curAnimated == lastAnimated) {
+                      // even if we don't send the change event, we need to set the reason...
+                    //this happens when you have multiple calls to setCamera very quickly. This method will short circuit,
+                    //and then the next time the user moves the map, it will think it is NOT from a user interaction , because
+                    // this flag was not reset
+                    mCameraChangeTracker.setReason(-1);
                     return;
                 }
 

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
@@ -885,6 +885,38 @@ public class RCTMGLMapView extends MapView implements
 
     //endregion
 
+    public void getBoundingCameraPosition(
+            String callbackID,
+            ReadableArray northEastCoordinates,
+            ReadableArray southWestCoordinates,
+            ReadableArray pad
+    ) {
+        WritableMap payload = new WritableNativeMap();
+        AndroidCallbackEvent event = new AndroidCallbackEvent(this, callbackID, EventKeys.MAP_ANDROID_CALLBACK);
+
+        int[] padding = {
+                pad.getInt(0),
+                pad.getInt(1),
+                pad.getInt(2),
+                pad.getInt(3),
+        };
+
+        LatLngBounds latLngBounds = LatLngBounds.from(
+                northEastCoordinates.getDouble(1),
+                northEastCoordinates.getDouble(0),
+                southWestCoordinates.getDouble(1),
+                southWestCoordinates.getDouble(0));
+        CameraPosition cameraPosition = mMap.getCameraForLatLngBounds(latLngBounds, padding);
+
+        payload.putDouble("latitude", cameraPosition.target.getLatitude());
+        payload.putDouble("longitude", cameraPosition.target.getLongitude());
+        payload.putDouble("zoom", cameraPosition.zoom);
+
+        event.setPayload(payload);
+
+        mManager.handleEvent(event);
+    }
+
     //region Methods
 
     public void setCamera(String callbackID, ReadableMap args) {

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapViewManager.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapViewManager.java
@@ -244,6 +244,7 @@ public class RCTMGLMapViewManager extends AbstractEventEmitter<RCTMGLMapView> {
     public static final int METHOD_TAKE_SNAP = 7;
     public static final int METHOD_GET_ZOOM = 8;
     public static final int METHOD_GET_CENTER = 9;
+    public static final int METHOD_GET_BOUNDING_CAMERA_POSITION = 10;
 
     @Nullable
     @Override
@@ -258,6 +259,7 @@ public class RCTMGLMapViewManager extends AbstractEventEmitter<RCTMGLMapView> {
                 .put("takeSnap", METHOD_TAKE_SNAP)
                 .put("getZoom", METHOD_GET_ZOOM)
                 .put("getCenter", METHOD_GET_CENTER)
+                .put("getBoundingCameraPosition", METHOD_GET_BOUNDING_CAMERA_POSITION)
                 .build();
     }
 
@@ -305,6 +307,14 @@ public class RCTMGLMapViewManager extends AbstractEventEmitter<RCTMGLMapView> {
                 break;
             case METHOD_GET_CENTER:
                 mapView.getCenter(args.getString(0));
+                break;
+            case METHOD_GET_BOUNDING_CAMERA_POSITION:
+                mapView.getBoundingCameraPosition(
+                        args.getString(0),
+                        args.getArray(1),
+                        args.getArray(2),
+                        args.getArray(3)
+                );
                 break;
         }
     }

--- a/javascript/components/MapView.js
+++ b/javascript/components/MapView.js
@@ -5,6 +5,7 @@ import {
   StyleSheet,
   NativeModules,
   requireNativeComponent,
+  Platform,
 } from 'react-native';
 import { makePoint, makeLatLngBounds } from '../utils/geoUtils';
 
@@ -464,6 +465,20 @@ class MapView extends React.Component {
       duration: duration,
       mode: MapboxGL.CameraModes.None,
     });
+  }
+
+  // Specific to scoot. This addresses the issue outlined in this mapbox react native issue.
+  // https://github.com/mapbox/react-native-mapbox-gl/issues/1218
+  async getBoundingCameraPositionForAndroid(northEastCoordinate, southWestCoordinate, padding) {
+    if (!this._nativeRef) {
+      return Promise.reject("No native reference found");
+    }
+
+    if (Platform.OS !== 'android') {
+      return Promise.reject("This may only be called by Android.")
+    }
+
+    return this._runNativeCommand('getBoundingCameraPosition', [northEastCoordinate, southWestCoordinate, padding]);
   }
 
   /**


### PR DESCRIPTION
Adding getBoundingCameraPosition perform math to later emulate fitBounds the Mapbox RN API.